### PR TITLE
get rid of the sidebar thing on mobile

### DIFF
--- a/global.css
+++ b/global.css
@@ -22,6 +22,7 @@
     display: block;
     padding-top: 7px;
     margin: 0 auto;
+    max-width: 100vw;
 }
 
 .nav-bar {


### PR DESCRIPTION
it turns out that the sidebar was from the banner image being too big I fixed that by adding a max-width of 100vw (100% of the viewport width)